### PR TITLE
Change `virt-manager`'s head repo's branch to `main`

### DIFF
--- a/virt-manager.rb
+++ b/virt-manager.rb
@@ -7,7 +7,7 @@ class VirtManager < Formula
   sha256 "2b6fe3d90d89e1130227e4b05c51e6642d89c839d3ea063e0e29475fd9bf7b86"
   revision 7
 
-  head "https://github.com/virt-manager/virt-manager.git"
+  head "https://github.com/virt-manager/virt-manager.git", :branch => "main"
 
   depends_on "docutils" => :build
   depends_on "gettext" => :build


### PR DESCRIPTION
The upstream branch name has renamed to `main` but Homebrew refers default to `master`.